### PR TITLE
PI-941: Fixed error which was causing frontend errors not to display.

### DIFF
--- a/src/js/actions/notifications.js
+++ b/src/js/actions/notifications.js
@@ -39,12 +39,23 @@ export function notificationRemove(key) {
 export function notificationAddClientAPIError(errorAction, errorMessage) {
     return dispatch => {
         dispatch(errorAction);
-        if(typeof errorMesages === 'string') {
-            dispatch(notificationAddError(errorMessages));
+        if(typeof errorMessage === 'string') {
+            dispatch(notificationAddError(errorMessage));
         } else {
             errorMessage.body.errors.forEach(function(error) {
                 dispatch(notificationAddError(error.message));
             });
+        }
+    };
+}
+
+export function notificationAddHostAPIError(errorAction, errorMessage) {
+    return dispatch => {
+        dispatch(errorAction);
+        if(typeof errorMessage === 'string') {
+            dispatch(notificationAddError(errorMessage));
+        } else {
+            dispatch(notificationAddError(errorMessage.body.msg));
         }
     };
 }

--- a/src/js/actions/pluginSettings.js
+++ b/src/js/actions/pluginSettings.js
@@ -1,7 +1,6 @@
 import {
     pluginSettingListGet,
-    pluginSettingPatch,
-    pluginResponseOk
+    pluginSettingPatch
 } from '../utils/PluginAPI/PluginAPI';
 import { notificationAddSuccess, notificationAddClientAPIError } from './notifications';
 import * as ActionTypes from '../constants/ActionTypes';
@@ -54,10 +53,10 @@ export function asyncPluginFetchSettings(zoneId) {
     return dispatch => {
         dispatch(pluginFetchSettings());
         pluginSettingListGet({ zoneId: zoneId }, function(error, response) {
-            if (pluginResponseOk(response)) {
+            if (response) {
                 dispatch(pluginFetchSettingsSuccess(zoneId, response.body.result));
             } else {
-                dispatch(notificationAddClientAPIError(pluginFetchSettingsError(), response));
+                dispatch(notificationAddClientAPIError(pluginFetchSettingsError(), error));
             }
         });
     };
@@ -69,14 +68,14 @@ export function asyncPluginUpdateSetting(settingName, zoneId, value) {
 
         dispatch(pluginUpdateSetting(zoneId, { id: settingName, value: value }));
         pluginSettingPatch(zoneId, settingName, value, function(error, response) {
-            if (pluginResponseOk(response)) {
+            if (response) {
                 dispatch(pluginUpdateSettingSuccess(zoneId, response.body.result));
 
                 if (settingName == 'default_settings') {
                     dispatch(notificationAddSuccess('container.applydefaultsettingscard.success', true));
                 }
             } else {
-                dispatch(notificationAddClientAPIError(pluginUpdateSettingError(zoneId, oldSetting), response));
+                dispatch(notificationAddClientAPIError(pluginUpdateSettingError(zoneId, oldSetting), error));
             }
         });
     };

--- a/src/js/actions/user.js
+++ b/src/js/actions/user.js
@@ -33,7 +33,7 @@ export function asyncUserLoginSuccess(email) {
         dispatch(asyncFetchZones());
         let route = UrlPaths.HOME_PAGE;
         if(getConfigValue(getState().config, 'integrationName') === 'cpanel') {
-          route = UrlPaths.DOMAINS_OVERVIEW_PAGE;
+          //route = UrlPaths.DOMAINS_OVERVIEW_PAGE;
         }
         dispatch(routeActions.push(route));
     };

--- a/src/js/actions/user.js
+++ b/src/js/actions/user.js
@@ -1,6 +1,6 @@
 import { routeActions } from 'redux-simple-router';
 import { userAuth, userCreate } from '../utils/CFHostAPI/CFHostAPI';
-import { pluginAccountPost, pluginResponseOk } from '../utils/PluginAPI/PluginAPI';
+import { pluginAccountPost } from '../utils/PluginAPI/PluginAPI';
 import { notificationAddHostAPIError, notificationAddClientAPIError } from './notifications';
 import * as ActionTypes from '../constants/ActionTypes';
 import * as UrlPaths from '../constants/UrlPaths';
@@ -59,11 +59,11 @@ export function asyncAPILogin(email, apiKey) {
     return dispatch => {
         dispatch(userLogin());
         pluginAccountPost(email, apiKey, function(error, response){
-            if(pluginResponseOk(response)) {
+            if(response) {
                 dispatch(asyncUserLoginSuccess(email));
             } else {
                 dispatch(userLoginError());
-                dispatch(notificationAddClientAPIError(userLoginError(), response));
+                dispatch(notificationAddClientAPIError(userLoginError(), error));
             }
         });
     };

--- a/src/js/actions/user.js
+++ b/src/js/actions/user.js
@@ -1,6 +1,6 @@
 import { routeActions } from 'redux-simple-router';
 import { userAuth, userCreate } from '../utils/CFHostAPI/CFHostAPI';
-import { pluginAccountPost, pluginResponseOk } from '../utils/PluginAPI/PluginAPI';
+import { pluginAccountPost } from '../utils/PluginAPI/PluginAPI';
 import { notificationAddHostAPIError, notificationAddClientAPIError } from './notifications';
 import * as ActionTypes from '../constants/ActionTypes';
 import * as UrlPaths from '../constants/UrlPaths';

--- a/src/js/actions/user.js
+++ b/src/js/actions/user.js
@@ -1,7 +1,7 @@
 import { routeActions } from 'redux-simple-router';
-import { userAuth, userCreate, hostAPIResponseOk } from '../utils/CFHostAPI/CFHostAPI';
+import { userAuth, userCreate } from '../utils/CFHostAPI/CFHostAPI';
 import { pluginAccountPost, pluginResponseOk } from '../utils/PluginAPI/PluginAPI';
-import { notificationAddError, notificationAddClientAPIError } from './notifications';
+import { notificationAddHostAPIError, notificationAddClientAPIError } from './notifications';
 import * as ActionTypes from '../constants/ActionTypes';
 import * as UrlPaths from '../constants/UrlPaths';
 
@@ -46,11 +46,10 @@ export function asyncLogin(email, password) {
     return dispatch => {
         dispatch(userLogin());
         userAuth({ cloudflare_email: email, cloudflare_pass: password }, function(error, response) {
-            if (hostAPIResponseOk(response)) {
+            if (response) {
                 dispatch(asyncUserLoginSuccess(response.body.response.cloudflare_email));
             } else {
-                dispatch(userLoginError());
-                dispatch(notificationAddError(response));
+                dispatch(notificationAddHostAPIError(userLoginError(), error));
             }
         });
     };
@@ -98,12 +97,11 @@ export function asyncUserSignup(email, password) {
     return dispatch => {
         dispatch(userSignup());
         userCreate({ cloudflare_email: email, cloudflare_pass: password }, function(error, response) {
-            if(hostAPIResponseOk(response)) {
+            if(response) {
                 dispatch(userSignupSuccess());
                 dispatch(asyncLogin(email, password));
             } else {
-                dispatch(userSignupError());
-                dispatch(notificationAddError(response));
+                dispatch(notificationAddHostAPIError(userSignupError(), error));
             }
         });
 

--- a/src/js/actions/user.js
+++ b/src/js/actions/user.js
@@ -1,9 +1,10 @@
 import { routeActions } from 'redux-simple-router';
 import { userAuth, userCreate } from '../utils/CFHostAPI/CFHostAPI';
-import { pluginAccountPost } from '../utils/PluginAPI/PluginAPI';
+import { pluginAccountPost, pluginResponseOk } from '../utils/PluginAPI/PluginAPI';
 import { notificationAddHostAPIError, notificationAddClientAPIError } from './notifications';
 import * as ActionTypes from '../constants/ActionTypes';
 import * as UrlPaths from '../constants/UrlPaths';
+import { getConfigValue } from '../selectors/config';
 
 import { asyncFetchZones } from './zones';
 
@@ -27,10 +28,14 @@ export function userLoginSuccess(email) {
 }
 
 export function asyncUserLoginSuccess(email) {
-    return dispatch => {
+    return (dispatch, getState) => {
         dispatch(userLoginSuccess(email));
         dispatch(asyncFetchZones());
-        dispatch(routeActions.push(UrlPaths.HOME_PAGE));
+        let route = UrlPaths.HOME_PAGE;
+        if(getConfigValue(getState().config, 'integrationName') === 'cpanel') {
+          route = UrlPaths.DOMAINS_OVERVIEW_PAGE;
+        }
+        dispatch(routeActions.push(route));
     };
 }
 

--- a/src/js/actions/user.js
+++ b/src/js/actions/user.js
@@ -33,7 +33,7 @@ export function asyncUserLoginSuccess(email) {
         dispatch(asyncFetchZones());
         let route = UrlPaths.HOME_PAGE;
         if(getConfigValue(getState().config, 'integrationName') === 'cpanel') {
-          //route = UrlPaths.DOMAINS_OVERVIEW_PAGE;
+          route = UrlPaths.DOMAINS_OVERVIEW_PAGE;
         }
         dispatch(routeActions.push(route));
     };

--- a/src/js/actions/zoneAnalytics.js
+++ b/src/js/actions/zoneAnalytics.js
@@ -1,4 +1,4 @@
-import { zoneAnalyticsDashboardGet, v4ResponseOk } from '../utils/CFClientV4API/CFClientV4API';
+import { zoneAnalyticsDashboardGet } from '../utils/CFClientV4API/CFClientV4API';
 import { notificationAddClientAPIError } from './notifications';
 import * as ActionTypes from '../constants/ActionTypes';
 
@@ -26,10 +26,10 @@ export function asyncZoneFetchAnalytics(zoneId) {
     return dispatch => {
         dispatch(zoneFetchAnalytics());
         zoneAnalyticsDashboardGet({ zoneId: zoneId, since: -43200 }, function(error, response){
-            if(v4ResponseOk(response)) {
+            if(response) {
                 dispatch(zoneFetchAnalyticsSuccess(zoneId, response.body.result));
             } else {
-                dispatch(notificationAddClientAPIError(zoneFetchAnalyticsError(), response));
+                dispatch(notificationAddClientAPIError(zoneFetchAnalyticsError(), error));
             }
         });
     };

--- a/src/js/actions/zoneDnsRecords.js
+++ b/src/js/actions/zoneDnsRecords.js
@@ -1,5 +1,5 @@
 import * as ActionTypes from '../constants/ActionTypes';
-import { zoneDNSRecordGetAll, zoneDNSRecordPostNew, zoneDNSRecordPatch, v4ResponseOk } from '../utils/CFClientV4API/CFClientV4API';
+import { zoneDNSRecordGetAll, zoneDNSRecordPostNew, zoneDNSRecordPatch } from '../utils/CFClientV4API/CFClientV4API';
 import { notificationAddClientAPIError } from './notifications';
 
 
@@ -35,12 +35,12 @@ export function asyncDNSRecordCreate(zoneId, type, name, content) {
     return dispatch => {
         dispatch(dnsRecordCreate(name));
         zoneDNSRecordPostNew({ zoneId: zoneId, type: type, name: name, content: content }, function(error, response) {
-            if(v4ResponseOk(response)) {
+            if(response) {
                 dispatch(dnsRecordCreateSuccess(zoneId, response.body.result));
                 //CloudFlare defaults new records with proxied = false.
                 dispatch(asyncDNSRecordUpdate(zoneId, response.body.result, true));
             } else {
-                dispatch(notificationAddClientAPIError(dnsRecordCreateError(), response));
+                dispatch(notificationAddClientAPIError(dnsRecordCreateError(), error));
             }
         });
     };
@@ -62,7 +62,7 @@ export function dnsRecordFetchListSuccess(zoneId, dnsRecords) {
 
 export function dnsRecordFetchListError() {
     return {
-        type: ActionTypes.DNS_RECORD_FETCH_LIST_SUCCESS
+        type: ActionTypes.DNS_RECORD_FETCH_LIST_ERROR
     };
 }
 
@@ -70,10 +70,10 @@ export function asyncDNSRecordFetchList(zoneId) {
     return dispatch => {
         dispatch(dnsRecordFetchList());
         zoneDNSRecordGetAll(zoneId, function(error, response) {
-            if(v4ResponseOk(response)) {
+            if(response) {
                 dispatch(dnsRecordFetchListSuccess(zoneId, response.body.result));
             } else {
-                dispatch(notificationAddClientAPIError(dnsRecordFetchListError(), response));
+                dispatch(notificationAddClientAPIError(dnsRecordFetchListError(), error));
             }
         });
     };
@@ -104,10 +104,10 @@ export function asyncDNSRecordUpdate(zoneId, dnsRecord, proxied) {
     return dispatch => {
         dispatch(dnsRecordUpdate(dnsRecord.name));
         zoneDNSRecordPatch({ zoneId: zoneId, dnsRecordId: dnsRecord.id, proxied: proxied }, function(error, response) {
-            if(v4ResponseOk(response)) {
+            if(response) {
                 dispatch(dnsRecordUpdateSuccess(zoneId, response.body.result));
             } else {
-                dispatch(notificationAddClientAPIError(dnsRecordUpdateError, response));
+                dispatch(notificationAddClientAPIError(dnsRecordUpdateError(), error));
             }
         });
     };

--- a/src/js/actions/zoneProvision.js
+++ b/src/js/actions/zoneProvision.js
@@ -4,7 +4,7 @@ import {
     v4ResponseOk
 } from '../utils/CFClientV4API/CFClientV4API';
 import { partialZoneSet, fullZoneSet, hostAPIResponseOk } from '../utils/CFHostAPI/CFHostAPI';
-import { notificationAddSuccess,notificationAddError } from './notifications';
+import { notificationAddSuccess, notificationAddError, notificationAddClientAPIError } from './notifications';
 import * as ActionTypes from '../constants/ActionTypes';
 import { asyncZoneSetActiveZone } from './activeZone';
 import { normalizeZoneGetAll } from '../constants/Schemas';
@@ -36,11 +36,11 @@ export function asyncZoneActivationCheck(zoneId) {
     return dispatch => {
         dispatch(zoneActivationCheck());
         zoneActivationCheckPutNew(zoneId, function(error, response) {
-            if(v4ResponseOk(response)) {
+            if(response) {
                 dispatch(zoneActivationCheckSuccess());
                 dispatch(notificationAddSuccess('container.activationCheckCard.success', true));
             } else {
-                dispatch(notificationAddClientAPIError(zoneActivationCheckError(), response));
+                dispatch(notificationAddClientAPIError(zoneActivationCheckError(), error));
             }
         });
     };

--- a/src/js/actions/zonePurgeCache.js
+++ b/src/js/actions/zonePurgeCache.js
@@ -1,4 +1,4 @@
-import { zonePurgeCache as v4ZonePurgeCache, v4ResponseOk } from '../utils/CFClientV4API/CFClientV4API';
+import { zonePurgeCache as v4ZonePurgeCache } from '../utils/CFClientV4API/CFClientV4API';
 import { notificationAddClientAPIError, notificationAddSuccess } from './notifications';
 import * as ActionTypes from '../constants/ActionTypes';
 
@@ -29,11 +29,11 @@ export function asyncZonePurgeCacheIndividualFiles(zoneId, files) {
         var formatedFiles = files.replace(/^\s+|\s+$/g,'').split(/\s+/);
 
         v4ZonePurgeCache({ zoneId: zoneId, files: formatedFiles }, function(error, response){
-            if(v4ResponseOk(response)) {
+            if(response) {
                 dispatch(zonePurgeCacheSuccess());
                 dispatch(notificationAddSuccess('container.purgeCacheCard.success', true));
             } else {
-                dispatch(notificationAddClientAPIError(zonePurgeCacheError(), response));
+                dispatch(notificationAddClientAPIError(zonePurgeCacheError(), error));
             }
         });
     };
@@ -43,11 +43,11 @@ export function asyncZonePurgeCacheEverything(zoneId) {
     return dispatch => {
         dispatch(zonePurgeCache());
         v4ZonePurgeCache({ zoneId: zoneId, purge_everything: true }, function(error, response){
-            if(v4ResponseOk(response)) {
+            if(response) {
                 dispatch(zonePurgeCacheSuccess());
                 dispatch(notificationAddSuccess('container.purgeCacheByURLCard.success', true));
             } else {
-                dispatch(notificationAddClientAPIError(zonePurgeCacheError(), response));
+                dispatch(notificationAddClientAPIError(zonePurgeCacheError(), error));
             }
         });
     };

--- a/src/js/actions/zoneRailgun.js
+++ b/src/js/actions/zoneRailgun.js
@@ -1,4 +1,4 @@
-import { zoneRailgunGetAll, zoneRailgunPatch, v4ResponseOk } from '../utils/CFClientV4API/CFClientV4API';
+import { zoneRailgunGetAll, zoneRailgunPatch } from '../utils/CFClientV4API/CFClientV4API';
 import { notificationAddClientAPIError } from './notifications';
 import * as ActionTypes from '../constants/ActionTypes';
 
@@ -26,10 +26,10 @@ export function asyncZoneRailgunFetchAll(zoneId) {
     return dispatch => {
         dispatch(zoneRailgunFetchAll());
         zoneRailgunGetAll(zoneId, function(error, response) {
-            if(v4ResponseOk(response)) {
+            if(response) {
                 dispatch(zoneRailgunFetchAllSuccess(zoneId, response.body.result));
             } else {
-                dispatch(notificationAddClientAPIError(zoneRailgunFetchAllError(), response));
+                dispatch(notificationAddClientAPIError(zoneRailgunFetchAllError(), error));
             }
         });
     };
@@ -64,10 +64,10 @@ export function asyncZoneRailgunConnectionUpdate(zoneId, railgun, isConnected) {
         let oldRailgun = Object.assign({}, railgun);
         dispatch(zoneRailgunConnectionUpdate(zoneId, Object.assign({}, railgun, { connected: isConnected })));
         zoneRailgunPatch(zoneId, railgun.id, isConnected, function(error, response) {
-            if(v4ResponseOk(response)) {
+            if(response) {
                 dispatch(zoneRailgunConnectionUpdateSuccess(zoneId, response.body.result));
             } else {
-                dispatch(notificationAddClientAPIError(zoneRailgunConnectionUpdateError(zoneId, oldRailgun), response));
+                dispatch(notificationAddClientAPIError(zoneRailgunConnectionUpdateError(zoneId, oldRailgun), error));
             }
         });
     };

--- a/src/js/actions/zoneSettings.js
+++ b/src/js/actions/zoneSettings.js
@@ -1,7 +1,6 @@
 import {
     zoneGetSettings,
-    zonePatchSetting,
-    v4ResponseOk
+    zonePatchSetting
 } from '../utils/CFClientV4API/CFClientV4API';
 import { notificationAddClientAPIError, notificationHandleDevelopmentMode } from './notifications';
 import * as ActionTypes from '../constants/ActionTypes';
@@ -30,13 +29,13 @@ export function asyncZoneFetchSettings(zoneId) {
     return dispatch => {
         dispatch(zoneFetchSettings());
         zoneGetSettings(zoneId, function(error, response){
-            if(v4ResponseOk(response)) {
+            if(response) {
                 dispatch(zoneFetchSettingsSuccess(zoneId, response.body.result));
 
                 // Lastly check if development mode value and add/remove notification
                 dispatch(notificationHandleDevelopmentMode(zoneId));
             } else {
-                dispatch(notificationAddClientAPIError(zoneFetchSettingsError(), response));
+                dispatch(notificationAddClientAPIError(zoneFetchSettingsError(), error));
             }
         });
     };
@@ -72,13 +71,13 @@ export function asyncZoneUpdateSetting(settingName, zoneId, value) {
 
         dispatch(zoneUpdateSetting(zoneId, { id: settingName, value: value }));
         zonePatchSetting(settingName, zoneId, value, function(error, response) {
-            if(v4ResponseOk(response)) {
+            if(response) {
                 dispatch(zoneUpdateSettingSuccess(zoneId, response.body.result));
 
                 // Lastly check if development mode value and add/remove notification
                 dispatch(notificationHandleDevelopmentMode(zoneId));
             } else {
-                dispatch(notificationAddClientAPIError(zoneUpdateSettingError(zoneId, oldSetting), response));
+                dispatch(notificationAddClientAPIError(zoneUpdateSettingError(zoneId, oldSetting), error));
             }
         });
     };

--- a/src/js/actions/zones.js
+++ b/src/js/actions/zones.js
@@ -3,7 +3,7 @@ import {
     zoneDeleteZone,
     v4ResponseOk
 } from '../utils/CFClientV4API/CFClientV4API';
-import { notificationAddError } from './notifications';
+import { notificationAddClientAPIError } from './notifications';
 import * as ActionTypes from '../constants/ActionTypes';
 import { zoneSetActiveZoneIfEmpty } from './activeZone';
 import { dnsRecordClearAll } from './zoneDnsRecords';
@@ -38,8 +38,7 @@ export function asyncZoneDelete(zoneId) {
                 //after we provision a cname refresh the zone list
                 dispatch(asyncFetchZones());
             } else {
-                dispatch(zoneDeleteError());
-                dispatch(notificationAddError(error.body.errors[0].message));
+                dispatch(notificationAddClientAPIError(zoneDeleteError(), error));
             }
         });
     };
@@ -76,8 +75,7 @@ export function asyncFetchZones() {
                         dispatch(zoneSetActiveZoneIfEmpty(response.body.result[0]));
                     }
                 } else {
-                    dispatch(zoneFetchError());
-                    dispatch(notificationAddError(response));
+                    dispatch(notificationAddClientAPIError(zoneFetchError(), error));
                 }
             });
     };

--- a/src/js/actions/zones.js
+++ b/src/js/actions/zones.js
@@ -39,7 +39,7 @@ export function asyncZoneDelete(zoneId) {
                 dispatch(asyncFetchZones());
             } else {
                 dispatch(zoneDeleteError());
-                dispatch(notificationAddError(response));
+                dispatch(notificationAddError(response.body.errors[0].message));
             }
         });
     };

--- a/src/js/actions/zones.js
+++ b/src/js/actions/zones.js
@@ -1,7 +1,6 @@
 import {
     zoneGetAll,
-    zoneDeleteZone,
-    v4ResponseOk
+    zoneDeleteZone
 } from '../utils/CFClientV4API/CFClientV4API';
 import { notificationAddClientAPIError } from './notifications';
 import * as ActionTypes from '../constants/ActionTypes';
@@ -69,7 +68,7 @@ export function asyncFetchZones() {
         dispatch(zoneFetch());
 
         zoneGetAll(function (error, response) {
-                if (v4ResponseOk(response)) {
+                if (response) {
                     dispatch(zoneFetchSuccess(response.body.result));
                     if(response.body.result[0]) {
                         dispatch(zoneSetActiveZoneIfEmpty(response.body.result[0]));

--- a/src/js/actions/zones.js
+++ b/src/js/actions/zones.js
@@ -32,14 +32,14 @@ export function asyncZoneDelete(zoneId) {
         dispatch(zoneDelete(zoneId));
 
         zoneDeleteZone(zoneId, function(error, response){
-            if(v4ResponseOk(response)) {
+            if(response) {
                 dispatch(zoneDeleteSuccess());
                 dispatch(dnsRecordClearAll(zoneId));
                 //after we provision a cname refresh the zone list
                 dispatch(asyncFetchZones());
             } else {
                 dispatch(zoneDeleteError());
-                dispatch(notificationAddError(response.body.errors[0].message));
+                dispatch(notificationAddError(error.body.errors[0].message));
             }
         });
     };

--- a/src/js/containers/AnalyticsPage/AnaltyicsPage.js
+++ b/src/js/containers/AnalyticsPage/AnaltyicsPage.js
@@ -11,6 +11,7 @@ import { format } from 'd3-format';
 import C3Wrapper from 'react-c3-wrapper';
 import _ from 'lodash';
 
+import { isActiveZoneOnCloudflare } from '../../selectors/activeZone';
 import { humanFileSize } from '../../utils/utils';
 import AnalyticCard from '../../components/AnalyticCard/AnalyticCard';
 
@@ -47,17 +48,18 @@ class AnaltyicsPage extends Component {
 
         const { formatMessage } = this.props.intl;
 
-        let { activeZoneId, allZoneAnalytics } = this.props;
-        let analytics = Object.assign({}, allZoneAnalytics[activeZoneId]);
+        let { activeZone, allZoneAnalytics } = this.props;
+        let analytics = Object.assign({}, allZoneAnalytics[activeZone.id]);
 
-        let isEmpty = _.isEmpty(analytics);
+        let isZoneOnCloudflare = isActiveZoneOnCloudflare(activeZone);
+        let isSettingsEmpty = _.isEmpty(analytics);
 
         let cached = formatMessage({ id: 'containers.analyticsPage.cached' });
         let unCached = formatMessage({ id: 'containers.analyticsPage.uncached' });
         let threats = formatMessage({ id: 'containers.analyticsPage.threats' });
         let uniques = formatMessage({ id: 'containers.analyticsPage.uniques' });
 
-        if (!isEmpty) {
+        if (!isSettingsEmpty) {
           // Get Top Country Threat 
           var threatsTopCountry = "N/A";
           var tempThreatsTopCountryValue = 0;
@@ -83,10 +85,13 @@ class AnaltyicsPage extends Component {
 
         return (
             <div>
-                {isEmpty && (
-                    <Text align="center"><Loading/></Text>
-                )}
-                {!isEmpty && (
+              {isSettingsEmpty && isZoneOnCloudflare && (
+                <Text align="center"><Loading/></Text>
+              )}
+              {isSettingsEmpty && !isZoneOnCloudflare && (
+                <Text align="center"><FormattedMessage id="errors.noActiveZoneSelected" /></Text>
+              )}
+              {!isSettingsEmpty && isZoneOnCloudflare && (
                     <div>
                     <Heading size={1}><FormattedMessage id="container.analyticsPage.title"/></Heading>
                     <Tabs
@@ -303,7 +308,7 @@ class AnaltyicsPage extends Component {
 }
 function mapStateToProps(state) {
     return {
-        activeZoneId: state.activeZone.id,
+        activeZone: state.activeZone,
         allZoneAnalytics: state.zoneAnalytics.entities,
     };
 }

--- a/src/js/containers/HomePage/HomePage.js
+++ b/src/js/containers/HomePage/HomePage.js
@@ -7,20 +7,25 @@ import { Heading } from 'cf-component-heading';
 import Loading from 'cf-component-loading';
 import Text from 'cf-component-text';
 
+import { isActiveZoneOnCloudflare } from '../../selectors/activeZone';
 import { getPluginSettingsForZoneId } from '../../selectors/pluginSettings';
 import { renderCards } from '../../components/RenderCardsDynamically/RenderCardsDynamically';
 
 class HomePage extends Component {
     render() {
-        let { activeZoneId, config, zoneSettings } = this.props;
-        let isEmpty = _.isEmpty(zoneSettings[activeZoneId]) && _.isEmpty(getPluginSettingsForZoneId(activeZoneId, this.state));
+        let { activeZone, zoneSettings } = this.props;
+        let isZoneOnCloudflare = isActiveZoneOnCloudflare(activeZone);
+        let isSettingsEmpty = _.isEmpty(zoneSettings[activeZone.id]) && _.isEmpty(getPluginSettingsForZoneId(activeZone.id, this.state));
 
         return (
-            <div>
-                {isEmpty && (
-                    <Text align="center"><Loading/></Text>
-                )}
-                {!isEmpty && (
+          <div>
+              {isSettingsEmpty && isZoneOnCloudflare && (
+                <Text align="center"><Loading/></Text>
+              )}
+              {isSettingsEmpty && !isZoneOnCloudflare && (
+                <Text align="center"><FormattedMessage id="errors.noActiveZoneSelected" /></Text>
+              )}
+              {!isSettingsEmpty && isZoneOnCloudflare && (
                     <div>
                         <Heading size={1}><FormattedMessage id="container.appNavigation.home"/></Heading>
                         
@@ -34,7 +39,7 @@ class HomePage extends Component {
 
 function mapStateToProps(state) {
     return {
-        activeZoneId: state.activeZone.id,
+        activeZone: state.activeZone,
         config: state.config.config,
         zoneSettings: state.zoneSettings.entities,
     };

--- a/src/js/containers/MoreSettingsPage/MoreSettingsPage.js
+++ b/src/js/containers/MoreSettingsPage/MoreSettingsPage.js
@@ -7,6 +7,7 @@ import { Heading } from 'cf-component-heading';
 import Loading from 'cf-component-loading';
 import Text from 'cf-component-text';
 
+import { isActiveZoneOnCloudflare } from '../../selectors/activeZone';
 import { getPluginSettingsForZoneId } from '../../selectors/pluginSettings';
 import { renderCards } from '../../components/RenderCardsDynamically/RenderCardsDynamically';
 
@@ -28,15 +29,19 @@ class MoreSettingsPage extends Component {
     }
 
     render() {
-        let { activeZoneId, zoneSettings } = this.props;
-        let isEmpty = _.isEmpty(zoneSettings[activeZoneId]) && _.isEmpty(getPluginSettingsForZoneId(activeZoneId, this.state));
+        let { activeZone, zoneSettings } = this.props;
+        let isZoneOnCloudflare = isActiveZoneOnCloudflare(activeZone);
+        let isSettingsEmpty = _.isEmpty(zoneSettings[activeZone.id]) && _.isEmpty(getPluginSettingsForZoneId(activeZone.id, this.state));
 
         return (
             <div>
-                {isEmpty && (
+                {isSettingsEmpty && isZoneOnCloudflare && (
                     <Text align="center"><Loading/></Text>
                 )}
-                {!isEmpty && (
+                {isSettingsEmpty && !isZoneOnCloudflare && (
+                  <Text align="center"><FormattedMessage id="errors.noActiveZoneSelected" /></Text>
+                )}
+                {!isSettingsEmpty && isZoneOnCloudflare && (
                     <div>
                         
                         { this.renderContent() }
@@ -49,7 +54,7 @@ class MoreSettingsPage extends Component {
 
 function mapStateToProps(state) {
     return {
-        activeZoneId: state.activeZone.id,
+        activeZone: state.activeZone,
         config: state.config.config,
         zoneSettings: state.zoneSettings.entities,
     };

--- a/src/js/selectors/activeZone.js
+++ b/src/js/selectors/activeZone.js
@@ -1,0 +1,3 @@
+export function isActiveZoneOnCloudflare(activeZone) {
+  return activeZone.id !== undefined;
+}

--- a/src/js/utils/CFClientV4API/CFClientV4API.js
+++ b/src/js/utils/CFClientV4API/CFClientV4API.js
@@ -48,8 +48,8 @@ export function v4Callback(callback) {
  *
  * @returns {Object} API Response
  */
-export function zoneActivationCheckPutNew(zoneId, onSuccess, onError) {
-    return http.put(ENDPOINT + '/zones/' + zoneId + '/activation_check', {}, onSuccess, onError);
+export function zoneActivationCheckPutNew(zoneId, callback) {
+    return http.put(ENDPOINT + '/zones/' + zoneId + '/activation_check', {}, v4Callback(callback));
 }
 
 /*

--- a/src/js/utils/CFClientV4API/CFClientV4API.js
+++ b/src/js/utils/CFClientV4API/CFClientV4API.js
@@ -85,8 +85,8 @@ export function zoneAnalyticsDashboardGet({ zoneId, since, until, continuous }, 
  *
  * @returns {Object} API Response
  */
-export function zoneDNSRecordGetAll(zoneId, onSuccess, onError) {
-    return http.get(ENDPOINT + '/zones/' + zoneId + '/dns_records', {}, onSuccess, onError);
+export function zoneDNSRecordGetAll(zoneId, callback) {
+    return http.get(ENDPOINT + '/zones/' + zoneId + '/dns_records', {}, v4Callback(callback));
 }
 
 /*
@@ -102,7 +102,7 @@ export function zoneDNSRecordGetAll(zoneId, onSuccess, onError) {
  *
  * @returns {Object} API Response
  */
-export function zoneDNSRecordPostNew({ zoneId, type, name, content, ttl }, onSuccess, onError) {
+export function zoneDNSRecordPostNew({ zoneId, type, name, content, ttl }, callback) {
     let opts = {
         body: {
             type: type,
@@ -112,7 +112,7 @@ export function zoneDNSRecordPostNew({ zoneId, type, name, content, ttl }, onSuc
     };
     if(ttl) {opts.body.ttl = ttl;}
 
-    return http.post(ENDPOINT + '/zones/' + zoneId + '/dns_records', opts, onSuccess, onError);
+    return http.post(ENDPOINT + '/zones/' + zoneId + '/dns_records', opts, v4Callback(callback));
 }
 
 /*
@@ -130,7 +130,7 @@ export function zoneDNSRecordPostNew({ zoneId, type, name, content, ttl }, onSuc
  *
  * @returns {Object} API Response
  */
-export function zoneDNSRecordPatch({ zoneId, dnsRecordId, type, name, content, proxied, ttl }, onSuccess, onError) {
+export function zoneDNSRecordPatch({ zoneId, dnsRecordId, type, name, content, proxied, ttl }, callback) {
     let opts = {
       body: {}
     };
@@ -141,7 +141,7 @@ export function zoneDNSRecordPatch({ zoneId, dnsRecordId, type, name, content, p
     if(typeof proxied !== 'undefined') { opts.body.proxied = proxied; }
     if(ttl) { opts.body.ttl = ttl; }
 
-    return http.patch(ENDPOINT + '/zones/' + zoneId + '/dns_records/' + dnsRecordId, opts, onSuccess, onError);
+    return http.patch(ENDPOINT + '/zones/' + zoneId + '/dns_records/' + dnsRecordId, opts, v4Callback(callback));
 }
 
 /*

--- a/src/js/utils/CFClientV4API/CFClientV4API.js
+++ b/src/js/utils/CFClientV4API/CFClientV4API.js
@@ -145,28 +145,6 @@ export function zoneDNSRecordPatch({ zoneId, dnsRecordId, type, name, content, p
 }
 
 /*
- * Create a new zone
- *
- * @param {String}   [name]
- * @param {Boolean}  [jump_start]
- * @param {Object}   [organization]
- * @param {Function} [onSuccess]
- * @param {Function} [onError]
- *
- * @returns {Object} API Response
- */
-export function zonePostNew({ name, jump_start, organization }, onSuccess, onError) {
-    let opts = {
-        body: {}
-    };
-
-    opts.body.name = name;
-    if(typeof jump_start !== 'undefined') { opts.body.jump_start = jump_start; }
-    if(organization) { opts.body.organization = organization; }
-    return http.post(ENDPOINT + '/zones', opts, onSuccess, onError);
-}
-
-/*
  * Purge the cache for a zone
  *
  * @param {String}   [zoneId]

--- a/src/js/utils/CFClientV4API/CFClientV4API.js
+++ b/src/js/utils/CFClientV4API/CFClientV4API.js
@@ -64,7 +64,7 @@ export function zoneActivationCheckPutNew(zoneId, callback) {
  *
  * @returns {Object} API Response
  */
-export function zoneAnalyticsDashboardGet({ zoneId, since, until, continuous }, onSuccess, onError) {
+export function zoneAnalyticsDashboardGet({ zoneId, since, until, continuous }, callback) {
     let opts = {
       parameters: {}
     };
@@ -73,7 +73,7 @@ export function zoneAnalyticsDashboardGet({ zoneId, since, until, continuous }, 
     if(until) { opts.parameters.until = until; }
     if(typeof continuous !== 'undefined') { opts.parameters.continuous = continuous; }
 
-    return http.get(ENDPOINT + '/zones/' + zoneId + '/analytics/dashboard', opts, onSuccess, onError);
+    return http.get(ENDPOINT + '/zones/' + zoneId + '/analytics/dashboard', opts, v4Callback(callback));
 }
 
 /*

--- a/src/js/utils/CFClientV4API/CFClientV4API.js
+++ b/src/js/utils/CFClientV4API/CFClientV4API.js
@@ -193,8 +193,8 @@ export function zoneGetAll(callback) {
  *
  * @returns {Object} API Response
  */
-export function zoneGetSettings(zoneId, onSuccess, onError) {
-    return http.get(ENDPOINT + '/zones/' + zoneId + '/settings', {}, onSuccess, onError);
+export function zoneGetSettings(zoneId, callback) {
+    return http.get(ENDPOINT + '/zones/' + zoneId + '/settings', {}, v4Callback(callback));
 }
 
 /*
@@ -208,13 +208,13 @@ export function zoneGetSettings(zoneId, onSuccess, onError) {
  *
  * @returns {Object} API Response
  */
-export function zonePatchSetting(settingName, zoneId, value, onSuccess, onError) {
+export function zonePatchSetting(settingName, zoneId, value, callback) {
     let opts = {
          body: {
              value: value
          }
     };
-    return http.patch(ENDPOINT + '/zones/' + zoneId + '/settings/' + settingName, opts, onSuccess, onError);
+    return http.patch(ENDPOINT + '/zones/' + zoneId + '/settings/' + settingName, opts, v4Callback(callback));
 }
 
 /*

--- a/src/js/utils/CFClientV4API/CFClientV4API.js
+++ b/src/js/utils/CFClientV4API/CFClientV4API.js
@@ -24,16 +24,16 @@ export function v4ResponseOk(response) {
  */
 export function v4Callback(callback) {
     return function(error, response) {
-        //return business logic errors as errors
-        if(response && !v4ResponseOk(response)) {
-            error = response;
-            response = null;
-        }
         if(response && response.text) {
             response.body = JSON.parse(response.text);
         }
         if(error && error.text) {
             error.body = JSON.parse(error.text);
+        }
+        //return business logic errors as errors
+        if(response && !v4ResponseOk(response)) {
+            error = response;
+            response = null;
         }
         return callback(error, response);
     }

--- a/src/js/utils/CFClientV4API/CFClientV4API.js
+++ b/src/js/utils/CFClientV4API/CFClientV4API.js
@@ -156,7 +156,7 @@ export function zoneDNSRecordPatch({ zoneId, dnsRecordId, type, name, content, p
  *
  * @returns {Object} API Response
  */
-export function zonePurgeCache({ zoneId, files, tags, purge_everything }, onSuccess, onError) {
+export function zonePurgeCache({ zoneId, files, tags, purge_everything }, callback) {
     let opts = {
         body: {}
     };
@@ -168,7 +168,7 @@ export function zonePurgeCache({ zoneId, files, tags, purge_everything }, onSucc
         if(tags) { opts.body.tags = tags; }
     }
 
-    return http.del(ENDPOINT + '/zones/' + zoneId + '/purge_cache', opts, onSuccess, onError);
+    return http.del(ENDPOINT + '/zones/' + zoneId + '/purge_cache', opts, v4Callback(callback));
 
 }
 

--- a/src/js/utils/CFClientV4API/CFClientV4API.js
+++ b/src/js/utils/CFClientV4API/CFClientV4API.js
@@ -14,6 +14,27 @@ export function v4ResponseOk(response) {
 }
 
 /*
+ * Our actions expect a single response because
+ * cf-util-http used to accept onSuccess(response), onError(response)
+ * and now accepts callback(error, response).  This callback will always
+ * pass errors as the response so they continue to work with our existing
+ * logic.  Also our backend returns errors with HTTP code 200 so
+ * cf-util-http doesn't recognize them as errors.
+ *
+ * @param {Function} callback
+ *
+ * @returns {Function} callback that passes correct error
+ */
+export function v4callback(callback) {
+    return function(error, response) {
+        if(response.text) {
+            response.body = JSON.parse(response.text);
+        }
+        return callback(error, response);
+    }
+}
+
+/*
  * Check if a zone has been activated
  *
  * @param {String}   [zoneId]
@@ -222,8 +243,8 @@ export function zonePatchSetting(settingName, zoneId, value, onSuccess, onError)
  *
  * @returns {Object} API Response
  */
-export function zoneDeleteZone(zoneId, onSuccess, onError) {
-    return http.del(ENDPOINT + '/zones/' + zoneId, {}, onSuccess, onError);
+export function zoneDeleteZone(zoneId, callback) {
+    return http.del(ENDPOINT + '/zones/' + zoneId, {}, v4callback(callback));
 }
 
 /*

--- a/src/js/utils/CFClientV4API/CFClientV4API.js
+++ b/src/js/utils/CFClientV4API/CFClientV4API.js
@@ -180,8 +180,8 @@ export function zonePurgeCache({ zoneId, files, tags, purge_everything }, callba
  *
  * @returns {Object} API Response
  */
-export function zoneGetAll(onSuccess, onError) {
-    return http.get(ENDPOINT + '/zones', {}, onSuccess, onError);
+export function zoneGetAll(callback) {
+    return http.get(ENDPOINT + '/zones', {}, v4Callback(callback));
 }
 
 /*

--- a/src/js/utils/CFClientV4API/CFClientV4API.js
+++ b/src/js/utils/CFClientV4API/CFClientV4API.js
@@ -43,8 +43,7 @@ export function v4Callback(callback) {
  * Check if a zone has been activated
  *
  * @param {String}   [zoneId]
- * @param {Function} [onSuccess]
- * @param {Function} [onError]
+ * @param {Function} [callback]
  *
  * @returns {Object} API Response
  */
@@ -59,8 +58,7 @@ export function zoneActivationCheckPutNew(zoneId, callback) {
  * @param {String}   [since]
  * @param {String}   [until]
  * @param {Boolean}  [continuous]
- * @param {Function} [onSuccess]
- * @param {Function} [onError]
+ * @param {Function} [callback]
  *
  * @returns {Object} API Response
  */
@@ -80,8 +78,7 @@ export function zoneAnalyticsDashboardGet({ zoneId, since, until, continuous }, 
  * Get all the DNS records for a zone
  *
  * @param {String}   [zoneId]
- * @param {Function} [onSuccess]
- * @param {Function} [onError]
+ * @param {Function} [callback]
  *
  * @returns {Object} API Response
  */
@@ -97,8 +94,7 @@ export function zoneDNSRecordGetAll(zoneId, callback) {
  * @param {String}   [name]
  * @param {String}   [content]
  * @param {String}   [ttl]
- * @param {Function} [onSuccess]
- * @param {Function} [onError]
+ * @param {Function} [callback]
  *
  * @returns {Object} API Response
  */
@@ -125,8 +121,7 @@ export function zoneDNSRecordPostNew({ zoneId, type, name, content, ttl }, callb
  * @param {String}   [content]
  * @param {Boolean}  [proxied]
  * @param {String}   [ttl]
- * @param {Function} [onSuccess]
- * @param {Function} [onError]
+ * @param {Function} [callback]
  *
  * @returns {Object} API Response
  */
@@ -151,8 +146,7 @@ export function zoneDNSRecordPatch({ zoneId, dnsRecordId, type, name, content, p
  * @param {Object}   [files]
  * @param {Object}   [tags]
  * @param {Boolean}  [purge_everything]
- * @param {Function} [onSuccess]
- * @param {Function} [onError]
+ * @param {Function} [callback]
  *
  * @returns {Object} API Response
  */
@@ -175,8 +169,7 @@ export function zonePurgeCache({ zoneId, files, tags, purge_everything }, callba
 /*
  * Get all a customer's zones
  *
- * @param {Function} [onSuccess]
- * @param {Function} [onError]
+ * @param {Function} [callback]
  *
  * @returns {Object} API Response
  */
@@ -188,8 +181,7 @@ export function zoneGetAll(callback) {
  * Get settings for a zone
  *
  * @param {String}   [zoneId]
- * @param {Function} [onSuccess]
- * @param {Function} [onError]
+ * @param {Function} [callback]
  *
  * @returns {Object} API Response
  */
@@ -203,8 +195,7 @@ export function zoneGetSettings(zoneId, callback) {
  * @param {String}   [settingName]
  * @param {String}   [zoneId]
  * @param {String}   [value]
- * @param {Function} [onSuccess]
- * @param {Function} [onError]
+ * @param {Function} [callback]
  *
  * @returns {Object} API Response
  */
@@ -221,8 +212,7 @@ export function zonePatchSetting(settingName, zoneId, value, callback) {
  * Delete a customer's zone
  *
  * @param {String}   [zoneId]
- * @param {Function} [onSuccess]
- * @param {Function} [onError]
+ * @param {Function} [callback]
  *
  * @returns {Object} API Response
  */
@@ -234,30 +224,28 @@ export function zoneDeleteZone(zoneId, callback) {
  * Get all available railguns for a zone
  *
  * @param {String}   [zoneId]
- * @param {Function} [onSuccess]
- * @param {Function} [onError]
+ * @param {Function} [callback]
  *
  * @returns {Object} API Response
  */
-export function zoneRailgunGetAll(zoneId, onSuccess, onError) {
-    return http.get(ENDPOINT + '/zones/' + zoneId + '/railguns', {}, onSuccess, onError);
+export function zoneRailgunGetAll(zoneId, callback) {
+    return http.get(ENDPOINT + '/zones/' + zoneId + '/railguns', {}, v4Callback(callback));
 }
 
 /*
  * Get all available railguns for a zone
  *
  * @param {String}   [zoneId]
- * @param {Function} [onSuccess]
- * @param {Function} [onError]
+ * @param {Function} [callback]
  *
  * @returns {Object} API Response
  */
-export function zoneRailgunPatch(zoneId, railgunId, connected, onSuccess, onError) {
+export function zoneRailgunPatch(zoneId, railgunId, connected, callback) {
     let opts = {
         body: {
             'connected': connected
         }
     };
     
-    return http.patch(ENDPOINT + '/zones/' + zoneId + '/railguns/' + railgunId, opts, onSuccess, onError);
+    return http.patch(ENDPOINT + '/zones/' + zoneId + '/railguns/' + railgunId, opts, v4Callback(callback));
 }

--- a/src/js/utils/PluginAPI/PluginAPI.js
+++ b/src/js/utils/PluginAPI/PluginAPI.js
@@ -33,7 +33,7 @@ export function pluginAccountPost(email, apiKey, callback) {
     return http.post(ENDPOINT + '/account/', opts, pluginCallback(callback));
 }
 
-export function pluginSettingListGet(zoneId, onSuccess, onError) {
+export function pluginSettingListGet(zoneId, callback) {
     let opts = {};
 
     return http.get(ENDPOINT + '/plugin/' + zoneId['zoneId'] + '/settings/', opts, pluginCallback(callback));

--- a/src/js/utils/PluginAPI/PluginAPI.js
+++ b/src/js/utils/PluginAPI/PluginAPI.js
@@ -1,5 +1,5 @@
 import http from 'cf-util-http';
-import { v4ResponseOk } from '../../utils/CFClientV4API/CFClientV4API';
+import { v4ResponseOk, v4Callback } from '../../utils/CFClientV4API/CFClientV4API';
 
 /*
  * This endpoint isn't real but we'll use it to identify REST calls for
@@ -19,28 +19,32 @@ export function pluginResponseOk(response) {
     return v4ResponseOk(response);
 }
 
-export function pluginAccountPost(email, apiKey, onSuccess, onError) {
+export function pluginCallback(callback) {
+    return v4Callback(callback);
+}
+
+export function pluginAccountPost(email, apiKey, callback) {
     let opts = {
         body: {
             email: email,
             apiKey: apiKey
         }
     };
-    return http.post(ENDPOINT + '/account/', opts, onSuccess, onError);
+    return http.post(ENDPOINT + '/account/', opts, pluginCallback(callback));
 }
 
 export function pluginSettingListGet(zoneId, onSuccess, onError) {
     let opts = {};
 
-    return http.get(ENDPOINT + '/plugin/' + zoneId['zoneId'] + '/settings/', opts, onSuccess, onError);
+    return http.get(ENDPOINT + '/plugin/' + zoneId['zoneId'] + '/settings/', opts, pluginCallback(callback));
 }
 
-export function pluginSettingPatch(zoneId, settingName, value, onSuccess, onError) {
+export function pluginSettingPatch(zoneId, settingName, value, callback) {
     let opts = {
         body: {
             value: value
         }
     };
 
-    return http.patch(ENDPOINT + '/plugin/' + zoneId + '/settings/' + settingName, opts, onSuccess, onError);
+    return http.patch(ENDPOINT + '/plugin/' + zoneId + '/settings/' + settingName, opts, pluginCallback(callback));
 }


### PR DESCRIPTION
I'm not sure how many of our actions this affects but here is the issue:

cf-util-http used to accept two callbacks, one for error, one for response:
```
http.request(method, url, options, function(success){...}, function(error){...});
```
but now accepts one callback:
```
http.request(method, url, options, function(error, success){...};
```

The root cause of this particular bug was the Advanced Zone Editor error was not propagating to the frontend because:

- The response was being returned in `response.text` not `response.body`
- The error was being returned as a `response`, not an `error`.

I created `v4callback` which check a response for `response.text`, JSON decode it, and set it as `response.body`.  I return it as a `response` and not an `error` because all of our actions do `if(v4ResponseOk(response)) {...} ` and haven't been updated to check for two variables instead of one. 

I didn't modify the rest of our actions because I'm not sure if this issue is unique to this particular action or if it affects all of them.  If it does affect all of them we just need to mimic the changes here.