### PR TITLE
Thellimist/pi 988

### DIFF
--- a/src/js/containers/Header/Header.js
+++ b/src/js/containers/Header/Header.js
@@ -13,12 +13,20 @@ class Header extends Component {
     render() {
         let { config, activeZone, zoneSettings } = this.props;
 
+        var logoStyle = {
+            width: "170px",
+            height: "30px",
+            position: "absolute",
+            top: "50%", 
+            transform: "translateY(-50%)"
+        }
+
         return(
             <header id="header" className="header app-header">
                 <div className="gradient-bar-header"></div>
                 <div id="header-global" className="header-main">
                     <LayoutColumn width={1/8}>
-                        <img style={{ margin: "15px 0", width: "170px", height: "30px" }} src={ getAbsoluteUrl(config, 'assets/logo.svg') } />
+                        <img style={logoStyle} src={ getAbsoluteUrl(config, 'assets/logo.svg') } />
                     </LayoutColumn>
                     <LayoutColumn width={1/8}>
                         <ActiveZoneSelector/>

--- a/src/js/containers/LoginPage/LoginPage.js
+++ b/src/js/containers/LoginPage/LoginPage.js
@@ -81,7 +81,7 @@ class LoginPage extends Component {
         let signupLinkWithUTM = generateUTMLink(CLOUDFLARE_SIGNUP_PAGE, config.integrationName, config.integrationName, SIGNUP_UTM_CONTENT_IDENTIFIER);
         let accountLinkWithUTM = generateUTMLink(CLOUDFLARE_ACCOUNT_PAGE, config.integrationName, config.integrationName, COPY_API_KEY_UTM_CONTENT_IDENTIFIER);
 
-        var overflowStyle = { overflow: "hidden", marginBottom: '2.5rem' };
+        var overflowStyle = { overflow: "hidden" };
 
         return (
           <div>
@@ -97,7 +97,7 @@ class LoginPage extends Component {
                           </div>
                           <FormFieldset legend="">
                               <div style={overflowStyle}>
-                                  <LayoutRow style={{ overflow: 'hidden' }}>
+                                  <LayoutRow style={overflowStyle}>
                                       <LayoutColumn width={1/1}>
                                           <FormLabel hidden><FormattedMessage id="component.clientLogin.form.email"/></FormLabel>
                                           <Input name="email" type="text" value={this.state.email} onChange={this.handleEmailChange.bind(this)} placeholder={formatMessage({ id: 'component.clientLogin.form.email' })}/>

--- a/src/js/containers/LoginPage/LoginPage.js
+++ b/src/js/containers/LoginPage/LoginPage.js
@@ -99,16 +99,16 @@ class LoginPage extends Component {
                               <div style={overflowStyle}>
                                   <LayoutRow style={overflowStyle}>
                                       <LayoutColumn width={1/1}>
-                                          <FormLabel hidden><FormattedMessage id="component.clientLogin.form.email"/></FormLabel>
-                                          <Input name="email" type="text" value={this.state.email} onChange={this.handleEmailChange.bind(this)} placeholder={formatMessage({ id: 'component.clientLogin.form.email' })}/>
+                                          <FormLabel><FormattedMessage id="component.clientLogin.form.email"/></FormLabel>
+                                          <Input name="email" type="text" value={this.state.email} onChange={this.handleEmailChange.bind(this)}/>
                                       </LayoutColumn>
                                   </LayoutRow>
                               </div>
                               <div style={{ overflow: "hidden", paddingBottom: "1px" }}>
                                   <LayoutRow>
                                       <LayoutColumn width={1/1}>
-                                          <FormLabel hidden><FormattedMessage id={ inputLabel }/></FormLabel>
-                                          <Input name="apiKey" type={ inputType } value={this.state.secret} onChange={this.handleSecretChange.bind(this)} placeholder={formatMessage({ id: inputLabel })}/>
+                                          <FormLabel><FormattedMessage id={ inputLabel }/></FormLabel>
+                                          <Input name="apiKey" type={ inputType } value={this.state.secret} onChange={this.handleSecretChange.bind(this)}/>
                                       </LayoutColumn>
                                   </LayoutRow>
                               </div>

--- a/src/js/containers/SignUpPage/SignUpPage.js
+++ b/src/js/containers/SignUpPage/SignUpPage.js
@@ -27,7 +27,7 @@ class SignUpPage extends Component {
   render() {
     let { formatMessage } = this.props.intl;
 
-    let overflowStyle = { overflow: "hidden", marginBottom: '2.5rem' };
+    let overflowStyle = { overflow: "hidden" };
 
     return (
         <div id="cf-login-page" style={{ margin: "2rem auto", maxWidth: '400px' }}>

--- a/src/js/containers/UnderAttackButton/UnderAttackButton.js
+++ b/src/js/containers/UnderAttackButton/UnderAttackButton.js
@@ -29,10 +29,12 @@ class UnderAttackButton extends Component {
         let buttonType = (value === 'under_attack') ? 'warning' : 'primary';
 
         let underAttackStyles = {
-            lineHeight: "60px",
             fontSize: "75%",
             textAlign: "right",
-            marginRight: "5px"
+            position: "absolute",
+            top: "50%",
+            width: "73%",
+            transform: "translateY(-50%)",
         };
 
         return (


### PR DESCRIPTION
Tried to style not completely but a bit like these resources

https://uxdesign.cc/design-better-forms-96fadca0f49c#.piaiw88fz
https://uxdesign.cc/alternatives-to-placeholder-text-13f430abc56f#.vhh5btmjr

- Removed placeholder text
- Added form label
- Removed ugly margin which was not possible to overwrite with hacks.css cause of no div name

The image below is styled with the following css. I added this to hacks.css even though it should be for every plugin.

```
#cf-login-page .cf-form__label {
    float: left;
    font-size: 13px;
}
```

<img width="1680" alt="screen shot 2017-02-01 at 14 13 20" src="https://cloud.githubusercontent.com/assets/6690196/22510407/c6ad76ec-e889-11e6-9964-9f74b797c02b.png">
