### PR TITLE
PI-1022: Fixed bug where ActiveZoneSelector with single zone (no sele…

### DIFF
--- a/src/containers/ActiveZoneSelector/ActiveZoneSelector.js
+++ b/src/containers/ActiveZoneSelector/ActiveZoneSelector.js
@@ -56,7 +56,8 @@ class ActiveZoneSelector extends Component {
       position: 'absolute',
       top: '50%',
       transform: 'translateY(-50%)',
-      width: '200px'
+      width: '200px',
+      marginLeft: '170px'
     };
 
     return (


### PR DESCRIPTION
Before:
<img width="398" alt="screen shot 2017-03-02 at 3 05 52 pm" src="https://cloud.githubusercontent.com/assets/6947158/23531228/56b81a94-ff5a-11e6-89aa-eb8b6fe80e44.png">
After:
<img width="331" alt="screen shot 2017-03-02 at 3 07 07 pm" src="https://cloud.githubusercontent.com/assets/6947158/23531234/5c6c66d4-ff5a-11e6-81b1-6a93d51d91e0.png">
170px is the width of the Cloudflare logo.  It doesn't affect the `<select>` (cPanel) because that component has separate class names.