### PR TITLE
PI-1056 fixed active zone selector not clickable bug

### DIFF
--- a/src/containers/ActiveZoneSelector/ActiveZoneSelector.js
+++ b/src/containers/ActiveZoneSelector/ActiveZoneSelector.js
@@ -53,12 +53,9 @@ class ActiveZoneSelector extends Component {
 
     //vertically center the active zone selector
     let activeZoneSelectorStyles = {
-      position: 'absolute',
-      top: '50%',
-      transform: 'translateY(-50%)',
-      width: '200px',
-      marginLeft: '170px',
-      zIndex: '1'
+      position: 'relative',
+      top: '30px', // Hard code .header-main height/2
+      transform: 'translateY(-50%)'
     };
 
     return (

--- a/src/containers/ActiveZoneSelector/ActiveZoneSelector.js
+++ b/src/containers/ActiveZoneSelector/ActiveZoneSelector.js
@@ -57,7 +57,8 @@ class ActiveZoneSelector extends Component {
       top: '50%',
       transform: 'translateY(-50%)',
       width: '200px',
-      marginLeft: '170px'
+      marginLeft: '170px',
+      zIndex: '1'
     };
 
     return (

--- a/src/containers/Header/Header.js
+++ b/src/containers/Header/Header.js
@@ -17,25 +17,29 @@ class Header extends Component {
     var logoStyle = {
       width: '170px',
       height: '30px',
-      position: 'absolute',
-      top: '50%',
+      position: 'relative',
+      top: '30px', // Hard code .header-main height/2
       transform: 'translateY(-50%)'
+    };
+
+    var columnStyle = {
+      position: 'relative'
     };
 
     return (
       <header id="header" className="header app-header">
         <div className="gradient-bar-header" />
         <div id="header-global" className="header-main">
-          <LayoutColumn width={1 / 8}>
+          <LayoutColumn width={1 / 8} style={columnStyle}>
             <img
               style={logoStyle}
               src={getAbsoluteUrl(config, 'assets/logo.svg')}
             />
           </LayoutColumn>
-          <LayoutColumn width={1 / 8}>
+          <LayoutColumn width={1 / 8} style={columnStyle}>
             <ActiveZoneSelector />
           </LayoutColumn>
-          <LayoutColumn width={6 / 8}>
+          <LayoutColumn width={6 / 8} style={columnStyle}>
             {isLoggedIn() && zoneSettings.entities[activeZone.id]
               ? <UnderAttackButton />
               : null}

--- a/src/containers/UnderAttackButton/UnderAttackButton.js
+++ b/src/containers/UnderAttackButton/UnderAttackButton.js
@@ -37,8 +37,9 @@ class UnderAttackButton extends Component {
     let underAttackStyles = {
       fontSize: '75%',
       textAlign: 'right',
-      position: 'absolute',
-      top: '50%',
+      position: 'relative',
+      top: '30px', // Hard code .header-main height/2
+      left: '25%',
       width: '73%',
       transform: 'translateY(-50%)'
     };


### PR DESCRIPTION
After the first zone switch, the div was being rendered below other divs so it wasn't recognizing the click. I did a quick `z-index`. The whole active zone selector CSS is a mess. We may need to fix it at some point