### PR TITLE
PI-1066 fixed bug with minify card

### DIFF
--- a/src/containers/MinifyCard/MinifyCard.js
+++ b/src/containers/MinifyCard/MinifyCard.js
@@ -39,8 +39,9 @@ class MinifyCard extends Component {
       html: 'off'
     };
 
+    // Convert items selected to 'on'
     checkboxValueList.forEach(function(item) {
-      apiValueList[item.value] = 'on';
+      apiValueList[item] = 'on';
     });
 
     let { activeZoneId, dispatch } = this.props;


### PR DESCRIPTION
`item` does not have `value` attribute. It's just a string. 

We've update cf-component-checkbox to 3.0.1 a month ago. But I've checked whether it was a bug caused by us or cf-ui. It seems like cf-ui update did not cause the bug. More interestingly this part of code has not been changed for 11 months. I remember testing every future before WP launch. So I've no idea how we introduced this bug. Also no one actually noticed it for a year...

Currently cf-ui is doing lots of updates. I'm happy with the current version so I choose not to update cf-component-checkbox to 3.2.0 which is the newest version.