### PR TITLE
set all APO values properly, fixes APO card rendering in CF dashboard

### DIFF
--- a/src/containers/AutomaticPlatformOptimization/AutomaticPlatformOptimizationCard.js
+++ b/src/containers/AutomaticPlatformOptimization/AutomaticPlatformOptimizationCard.js
@@ -50,7 +50,10 @@ class AutomaticPlatformOptimizationCard extends Component {
 
     dispatch(
       asyncZoneUpdateSetting(SETTING_NAME, activeZoneId, {
-        enabled: value
+        enabled: value,
+        cf: true, // the zone is orange clouded
+        wordpress: true, // wordpress is detected
+        wp_plugin: true // wp plugin is detected
       })
     );
     dispatch(asyncPluginUpdateSetting(SETTING_NAME, activeZoneId, value));


### PR DESCRIPTION
I forgot to set helper values for APO settings, this fixes APO card rendering in CF dashboard, it will indicate that WordPress and WP plugin has been detected. 