### PR TITLE
APO-147 support of subdomains for APO card

### DIFF
--- a/lang/en.js
+++ b/lang/en.js
@@ -191,6 +191,7 @@
     "container.automaticplatformoptimization.title": "Automatic Platform Optimization",
     "container.automaticplatformoptimization.description": "Improve the performance of your WordPress site. Automatic Platform Optimization for WordPress serves your WordPress site from Cloudflare's edge network and caches third party fonts. Get the benefits of a static site without any changes to how you manage your site. This results in consistent, fast TTFB and content loading faster.",
     "container.automaticplatformoptimization.drawer.help": "For more information about how APO provides better performance to your WordPress site, see [this](https://support.cloudflare.com/hc/en-us/articles/360049822312) support article.",
+    "container.automaticplatformoptimization.description_hostnames": "**Note:** APO runs against the following list of hostnames:\n\n_{hostnames}_",
     "container.purgeCacheCard.dropdown": "Purge Cache",
     "container.purgeCacheCard.button": "Purge Everything",
     "container.purgeCacheCard.title": "Purge Cache",

--- a/src/components/FormattedMarkdown/FormattedMarkdown.js
+++ b/src/components/FormattedMarkdown/FormattedMarkdown.js
@@ -17,13 +17,15 @@ import { getConfigValue } from '../../selectors/config.js';
 // <FormattedMarkdown text="mycomponent.myfeature" />
 class FormattedMarkdown extends Component {
   render() {
-    let { integrationName } = this.props;
+    let { integrationName, formattedMessage } = this.props;
 
-    var formattedMessage = formatMessageForIntegration(
-      this.props.intl,
-      this.props.text,
-      integrationName
-    );
+    if (!formattedMessage) {
+      formattedMessage = formatMessageForIntegration(
+        this.props.intl,
+        this.props.text,
+        integrationName
+      );
+    }
 
     var md = new MarkdownIt();
 
@@ -38,8 +40,8 @@ class FormattedMarkdown extends Component {
 }
 
 FormattedMarkdown.propTypes = {
-  text: PropTypes.string.isRequired,
-  formattedMessage: PropTypes.func,
+  text: PropTypes.string,
+  formattedMessage: PropTypes.string,
   intl: PropTypes.object,
   integrationName: PropTypes.string
 };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,19 +1,3 @@
-// Source: http://stackoverflow.com/a/23945027/4335588
-function extractDomain(url) {
-  var domain;
-  // find & remove protocol (http, ftp, etc.) and get domain
-  if (url.indexOf('://') > -1) {
-    domain = url.split('/')[2];
-  } else {
-    domain = url.split('/')[0];
-  }
-
-  // find & remove port number
-  domain = domain.split(':')[0];
-
-  return domain;
-}
-
 function beginsWith(needle, haystack) {
   return haystack.substr(0, needle.length) == needle;
 }
@@ -23,7 +7,7 @@ function endsWith(str, suffix) {
 }
 
 export function isSubdomain(selectedZoneName) {
-  var currentDomainName = extractDomain(document.URL);
+  var currentDomainName = new URL(document.URL).hostname;
 
   if (
     endsWith(currentDomainName, selectedZoneName) &&


### PR DESCRIPTION
Once APO feature is enabled against subdomain we push changes to start accepting traffic through APO on the selected subdomain.
There is a special case for apex, we will add/remove both apex and www subdomain to the list of allowed hostnames.

Added list of zone's hostnames we ran feature against:
<img width="877" alt="Screen Shot 2020-11-18 at 7 43 48 PM" src="https://user-images.githubusercontent.com/125466/99580070-f9770880-29d6-11eb-8d66-5b6095a43e1e.png">

The case when APO is disabled against current hostname but runs on another hostname:
<img width="878" alt="Screen Shot 2020-11-18 at 7 43 59 PM" src="https://user-images.githubusercontent.com/125466/99580172-18759a80-29d7-11eb-872f-b9aded3db518.png">
 