### PR TITLE
Release v3.2.2

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.2.2](#3.2.2) - 2020-11-19
+### Fixed
+- APO-147 support of subdomains for APO card [#159](https://github.com/cloudflare/cloudflare-plugin-frontend/pull/159)
+
 ## [3.2.1](#3.2.1) - 2020-10-05
 ### Fixed
 - Set all APO values properly to fix dashboard rendering [#156](https://github.com/cloudflare/cloudflare-plugin-frontend/pull/156)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-plugin-frontend",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "A React/Redux frontend for Cloudflare plugins",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
## [3.2.2](#3.2.2) - 2020-11-19
### Fixed
- APO-147 support of subdomains for APO card [#159](https://github.com/cloudflare/cloudflare-plugin-frontend/pull/159)