### PR TITLE
APO-185 bugfix how we handle hostnames, APO settings on subdomain

### DIFF
--- a/lang/en.js
+++ b/lang/en.js
@@ -193,7 +193,7 @@
     "container.automaticplatformoptimization.drawer.help": "For more information about how APO provides better performance to your WordPress site, see [this](https://support.cloudflare.com/hc/en-us/articles/360049822312) support article.",
     "container.automaticplatformoptimization.description_hostnames": "**Note:** APO runs against the following list of hostnames:\n\n_{hostnames}_",
     "container.automaticplatformoptimization.cache_by_device_type": "Cache By Device Type",
-    "container.automaticplatformoptimization.cache_by_device_type_note": "**Note:** Changing Cache By Device Type setting will invalidate Cache.",
+    "container.automaticplatformoptimization.cache_by_device_type_note": "**Note:** Changing Cache By Device Type setting will invalidate Cache. The setting is applied to all hostnames",
     "container.purgeCacheCard.dropdown": "Purge Cache",
     "container.purgeCacheCard.button": "Purge Everything",
     "container.purgeCacheCard.title": "Purge Cache",

--- a/lang/en.js
+++ b/lang/en.js
@@ -192,6 +192,8 @@
     "container.automaticplatformoptimization.description": "Improve the performance of your WordPress site. Automatic Platform Optimization for WordPress serves your WordPress site from Cloudflare's edge network and caches third party fonts. Get the benefits of a static site without any changes to how you manage your site. This results in consistent, fast TTFB and content loading faster.",
     "container.automaticplatformoptimization.drawer.help": "For more information about how APO provides better performance to your WordPress site, see [this](https://support.cloudflare.com/hc/en-us/articles/360049822312) support article.",
     "container.automaticplatformoptimization.description_hostnames": "**Note:** APO runs against the following list of hostnames:\n\n_{hostnames}_",
+    "container.automaticplatformoptimization.cache_by_device_type": "Cache By Device Type",
+    "container.automaticplatformoptimization.cache_by_device_type_note": "**Note:** Changing Cache By Device Type setting will invalidate Cache.",
     "container.purgeCacheCard.dropdown": "Purge Cache",
     "container.purgeCacheCard.button": "Purge Everything",
     "container.purgeCacheCard.title": "Purge Cache",

--- a/lang/en.js
+++ b/lang/en.js
@@ -274,7 +274,7 @@
     "constants.plans.biz": "Business plan",
     "constants.plans.ent": "Enterprise plan",
     "errors.noActiveZoneSelected": "It looks like your domain {domain} is not provisioned with Cloudflare. Please continue to {link} to secure and speed up your website.",
-    "warning.usingSubdomain": "You are using a subdomain for your site, but any Cloudflare settings applied via this plugin will be applied to your original domain as well.",
+    "warning.usingSubdomain": "You are using a subdomain for your site, apart from the APO feature, any Cloudflare settings applied via this plugin will be applied to your original domain as well.",
     "warning.developmentmode": "Development mode enabled, all traffic will bypass the Cloudflare cache.",
     "utils.utils.lastmodifieddate": "This settings was last changed {date}"
 }

--- a/src/containers/AutomaticPlatformOptimization/AutomaticPlatformOptimizationCard.js
+++ b/src/containers/AutomaticPlatformOptimization/AutomaticPlatformOptimizationCard.js
@@ -63,27 +63,36 @@ class AutomaticPlatformOptimizationCard extends Component {
     let {
       activeZoneId,
       dispatch,
-      settings: { hostnames = [] },
-      defaultHostnames
+      settings: { hostnames = [], cf, wordpress, wp_plugin, enabled },
+      defaultHostnames,
+      isSubdomain
     } = this.props;
 
-    if (value) {
-      hostnames.push(...defaultHostnames.filter(h => !hostnames.includes(h)));
-    } else {
-      _.remove(hostnames, h => defaultHostnames.includes(h));
+    if (enabled) {
+      if (value) {
+        // extend hostnames when APO was enabled already
+        hostnames.push(...defaultHostnames.filter(h => !hostnames.includes(h)));
+      } else {
+        _.remove(hostnames, h => defaultHostnames.includes(h));
 
-      // keep feature enabled if there are other hostnames
-      if (hostnames.length > 0) {
-        value = true;
+        // keep feature enabled if there are other hostnames
+        if (hostnames.length > 0) {
+          value = true;
+        }
+      }
+    } else {
+      if (value) {
+        // override hostnames when APO was disabled
+        hostnames = [...defaultHostnames];
       }
     }
 
     dispatch(
       asyncZoneUpdateSetting(SETTING_NAME, activeZoneId, {
         enabled: value,
-        cf: true, // the zone is orange clouded
-        wordpress: true, // wordpress is detected
-        wp_plugin: true, // wp plugin is detected
+        cf: isSubdomain ? cf : true, // the zone is orange clouded, override only on the root
+        wordpress: isSubdomain ? wordpress : true, // wordpress is detected, override only on the root
+        wp_plugin: isSubdomain ? wp_plugin : true, // wp plugin is detected, override only on the root
         hostnames
       })
     );

--- a/src/containers/AutomaticPlatformOptimization/AutomaticPlatformOptimizationCard.js
+++ b/src/containers/AutomaticPlatformOptimization/AutomaticPlatformOptimizationCard.js
@@ -14,8 +14,13 @@ import {
 } from '../../selectors/zoneSettings';
 import CustomCardControl from '../../components/CustomCardControl/CustomCardControl';
 import _ from 'lodash';
+import { Checkbox } from 'cf-component-checkbox';
 
 const SETTING_NAME = 'automatic_platform_optimization';
+
+const checkboxStyle = {
+  marginTop: '1rem'
+};
 
 class AutomaticPlatformOptimizationCard extends Component {
   constructor(props) {
@@ -63,7 +68,14 @@ class AutomaticPlatformOptimizationCard extends Component {
     let {
       activeZoneId,
       dispatch,
-      settings: { hostnames = [], cf, wordpress, wp_plugin, enabled },
+      settings: {
+        hostnames = [],
+        cf,
+        wordpress,
+        wp_plugin,
+        enabled,
+        cache_by_device_type = false
+      },
       defaultHostnames,
       isSubdomain
     } = this.props;
@@ -93,10 +105,37 @@ class AutomaticPlatformOptimizationCard extends Component {
         cf: isSubdomain ? cf : true, // the zone is orange clouded, override only on the root
         wordpress: isSubdomain ? wordpress : true, // wordpress is detected, override only on the root
         wp_plugin: isSubdomain ? wp_plugin : true, // wp plugin is detected, override only on the root
-        hostnames
+        hostnames,
+        cache_by_device_type
       })
     );
     dispatch(asyncPluginUpdateSetting(SETTING_NAME, activeZoneId, value));
+  }
+
+  handleCacheByDeviceTypeChange() {
+    let {
+      activeZoneId,
+      dispatch,
+      settings: {
+        hostnames = [],
+        cf,
+        wordpress,
+        wp_plugin,
+        enabled,
+        cache_by_device_type = false
+      }
+    } = this.props;
+
+    dispatch(
+      asyncZoneUpdateSetting(SETTING_NAME, activeZoneId, {
+        enabled,
+        cf,
+        wordpress,
+        wp_plugin,
+        hostnames,
+        cache_by_device_type: !cache_by_device_type
+      })
+    );
   }
 
   render() {
@@ -104,7 +143,7 @@ class AutomaticPlatformOptimizationCard extends Component {
     const {
       modifiedDate,
       entitlements,
-      settings: { hostnames = [], enabled },
+      settings: { hostnames = [], enabled, cache_by_device_type = false },
       defaultHostnames
     } = this.props;
 
@@ -138,6 +177,10 @@ class AutomaticPlatformOptimizationCard extends Component {
               <div>
                 <FormattedMessage id="container.automaticplatformoptimization.description" />
 
+                <FormattedMarkdown text="container.automaticplatformoptimization.drawer.help" />
+
+                <FormattedMarkdown text="container.automaticplatformoptimization.cache_by_device_type_note" />
+
                 {enabled && (
                   <FormattedMarkdown formattedMessage={hostnamesMessage} />
                 )}
@@ -148,11 +191,26 @@ class AutomaticPlatformOptimizationCard extends Component {
               purchaseSubscriptionPath={'/speed/optimization/apo/purchase'}
               indentifier={SETTING_NAME}
             >
-              <Toggle
-                label=""
-                value={this.isFeatureEnabled()}
-                onChange={this.handleChange.bind(this)}
-              />
+              <div>
+                <Toggle
+                  label=""
+                  value={this.isFeatureEnabled()}
+                  onChange={this.handleChange.bind(this)}
+                />
+                <div style={checkboxStyle}>
+                  <Checkbox
+                    name={''}
+                    value={''}
+                    label={formatMessage({
+                      id:
+                        'container.automaticplatformoptimization.cache_by_device_type'
+                    })}
+                    checked={!!cache_by_device_type}
+                    onChange={this.handleCacheByDeviceTypeChange.bind(this)}
+                    disabled={!enabled}
+                  />
+                </div>
+              </div>
             </CustomCardControl>
           </CardSection>
           <CardDrawers


### PR DESCRIPTION
2 bugfixes:
- don't change APO settings (cf, wordpress, plugin) when running on subdomain, it could cause enabling APO on the root via dashboard
- override hostnames when APO was disabled and we enable it in plugin. 

Cache by device type integration:
<img width="1024" alt="Screen Shot 2020-12-07 at 12 14 29 PM" src="https://user-images.githubusercontent.com/125466/101376963-2d906b80-38a9-11eb-8560-66ff45be9a47.png">
