### PR TITLE
Release v3.2.3

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.2.3](#3.2.3) - 2020-12-07
+### Fixed
+- APO-185 bugfix how we handle hostnames, APO settings on subdomain [#161](https://github.com/cloudflare/cloudflare-plugin-frontend/pull/161)
+
 ## [3.2.2](#3.2.2) - 2020-11-19
 ### Fixed
 - APO-147 support of subdomains for APO card [#159](https://github.com/cloudflare/cloudflare-plugin-frontend/pull/159)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudflare-plugin-frontend",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "A React/Redux frontend for Cloudflare plugins",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
## [3.2.3](#3.2.3) - 2020-12-07
### Fixed
- APO-185 bugfix how we handle hostnames, APO settings on subdomain [#161](https://github.com/cloudflare/cloudflare-plugin-frontend/pull/161)