### PR TITLE
enforce eslint no-use-before-define

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,7 +60,8 @@ module.exports = {
     'import/no-unresolved': 0,
     'import/first': 1,
     'prettier/prettier': [2, { trailingComma: 'none', singleQuote: true }],
-    'compat/compat': 0
+    'compat/compat': 0,
+    'no-use-before-define': ['error', { functions: false, classes: true }]
   },
   settings: {
     'import/resolver': {

--- a/src/components/CustomCardControl/CustomCardControl.js
+++ b/src/components/CustomCardControl/CustomCardControl.js
@@ -22,7 +22,7 @@ class CustomCardControl extends Component {
     } = this.props;
 
     if (purchaseSubscription && purchaseSubscriptionPath) {
-      upgradeLink = `https://dash.cloudflare.com/${activeZone.account.id}/${activeZone.name}${purchaseSubscriptionPath}`;
+      let upgradeLink = `https://dash.cloudflare.com/${activeZone.account.id}/${activeZone.name}${purchaseSubscriptionPath}`;
       return (
         <CardControl>
           {purchaseSubscription ? (


### PR DESCRIPTION
https://eslint.org/docs/rules/no-use-before-define.

Should fix:
```
Uncaught ReferenceError: can't access lexical declaration 'u' before initialization
    render http://wordpress.lol:9999/wp-content/plugins/cloudflare/compiled.js?ver=4.6.0:54
    _renderValidatedComponentWithoutOwnerOrContext http://wordpress.lol:9999/wp-content/plugins/cloudflare/compiled.js?ver=4.6.0:50
    _renderValidatedComponent http://wordpress.lol:9999/wp-content/plugins/cloudflare/compiled.js?ver=4.6.0:50
    performInitialMount http://wordpress.lol:9999/wp-content/plugins/cloudflare/compiled.js?ver=4.6.0:50
    mountComponent http://wordpress.lol:9999/wp-content/plugins/cloudflare/compiled.js?ver=4.6.0:50
    mountComponent http://wordpress.lol:9999/wp-content/plugins/cloudflare/compiled.js?ver=4.6.0:20
    performInitialMount http://wordpress.lol:9999/wp-content/plugins/cloudflare/compiled.js?ver=4.6.0:50
    mountComponent http://wordpress.lol:9999/wp-content/plugins/cloudflare/compiled.js?ver=4.6.0:50
    mountComponent http://wordpress.lol:9999/wp-content/plugins/cloudflare/compiled.js?ver=4.6.0:20
```