### PR TITLE
Update lodash to version 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
     "cf-component-box": "^2.2.1",
     "cf-style-provider": "^1.5.0",
     "prop-types": "^15.5.8",
-    "webpack-cli": "^4.6.0"
+    "webpack-cli": "^4.6.0",
+    "lodash": "^4.0.0"
   },
   "browserslist": "> 1%"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5381,18 +5381,14 @@ lodash@3.7.x:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.7.0.tgz#3678bd8ab995057c07ade836ed2ef087da811d45"
 
-lodash@^3.10.1:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.2.0, lodash@^4.7.0:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 lodash@^4.1.0, lodash@^4.17.2, lodash@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.2.0, lodash@^4.7.0:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.0.0, loose-envify@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
This pull request was created using the JSFIX program analysis (https://jsfix.live) by Coana.tech (https://coana.tech).

It bumps lodash to version 4.0.0.

<details>
<summary>List of breaking changes where JSFIX found that there were no occurrences.</summary>

* Dropped boolean options param support in _.debounce, _.mixin, & _.throttle
* Split _.indexOf & _.lastIndexOf into _.sortedIndexOf & _.sortedLastIndexOf
* Split _.sum into _.sumBy
* Renamed _.invoke to _.invokeMap
* Split _.sortedLastIndex into _.sortedLastIndexBy
* Split _.invert into _.invertBy (see v4.1.0)
* Renamed _.restParam to _.rest
* Absorbed _.sortByAll into _.sortBy
* Renamed _.sortByOrder to _.orderBy
* Renamed _.trunc to _.truncate
* Made _#times, _#forEach, _#forIn, _#forOwn, & their right-forms implicitly end chain sequences
* Removed support for binding all methods by default from _.bindAll
* Split _.merge into _.mergeWith
* Split _.clone & _.cloneDeep into _.cloneWith & _.cloneDeepWith
* 17 aliases removed
* Renamed _.padLeft & _.padRight to _.padStart & _.padEnd
* Removed thisArg params from most methods because they were largely unused, complicated implementations, & can be tackled with _.bind, Function#bind, or arrow functions
* Split _.sample into _.sampleSize
* Split _.uniq into _.sortedUniq, _.sortedUniqBy, & _.uniqBy
* Removed _.findWhere in favor of _.find with iteratee shorthand
* Renamed _.pairs to _.toPairs
* Made _.escapeRegExp align to the defunct ES7 proposal
* Split _.omit & _.pick into _.omitBy & _.pickBy
* Split _.max & _.min into _.maxBy & _.minBy
* Removed _.support
* Changed the category of _.bindAll to “Util”
* Split _.isMatch into _.isMatchWith
* Made _.capitalize uppercase the first character & lowercase the rest (see _.upperFirst)
* Made _.max, _.min, & _.sum support arrays only
* Changed _.matchesProperty shorthand to an array of [path, srcValue]
* Renamed _.trimLeft & _.trimRight to _.trimStart & _.trimEnd
* Renamed _.modArgs to _.overArgs
* Made _.words chainable by default
* Dropped support for boolean orders param in _.orderBy
* Removed category names from module paths
* Changed the category of _.at to “Object”
* Made _.max & _.min return undefined when passed an empty array
* Made _.add, _.max, _.min, & _.sum no longer coerce values to numbers
* Removed _.pluck in favor of _.map with iteratee shorthand
* Made “By” methods like _.groupBy & _.sortBy provide a single param to iteratees
* Removed _.where in favor of _.filter with iteratee shorthand
* Made _.functions return only own method names
* Split _.assign & _.assignIn into _.assignWith & _.assignInWith
* Split _.isEqual into _.isEqualWith
* Made _.eq its own method instead of an alias for _.isEqual
* Renamed _.indexBy to _.keyBy
* Split _.sortedIndex into _.sortedIndexBy
* Removed isDeep params from _.clone & _.flatten
* Renamed _.rest to _.tail
* Split _.zipObject into _.fromPairs
</details>

<details>
<summary>List of breaking changes not automatically fixable by JSFIX (<b>manual review before merge is recommended</b>).</summary>

* Dropped IE 6-8 support


</details>

<details>
<summary>List of breaking changes not patched because they are very unlikely to affect clients (<b>manual review before merge is recommended</b>.</summary>

* merge will now assign a source property to the destination object if that property resolves to undefined on the source object and the property does not exist on the destination object

  - [src/reducers/pluginSettings.js#L24-L24](https://github.com/cloudflare/cloudflare-plugin-frontend/pull/187/commits/f42b38f9984b06c14389bbbdca7fea79c2f7880f#diff-402021cda1ac76018edf17db9b9e01b733d8a3f92bc00cb84eb4ade95f2c51edL24-L24)
  - [src/reducers/pluginSettings.js#L25-L25](https://github.com/cloudflare/cloudflare-plugin-frontend/pull/187/commits/f42b38f9984b06c14389bbbdca7fea79c2f7880f#diff-402021cda1ac76018edf17db9b9e01b733d8a3f92bc00cb84eb4ade95f2c51edL25-L25)
  - [src/reducers/zoneDnsRecords.js#L50-L50](https://github.com/cloudflare/cloudflare-plugin-frontend/pull/187/commits/f42b38f9984b06c14389bbbdca7fea79c2f7880f#diff-90d5832691c95e10301ee697a568ddf7f8ad7609bc58143fe21352365953d6dbL50-L50)
  - [src/reducers/zoneDnsRecords.js#L51-L51](https://github.com/cloudflare/cloudflare-plugin-frontend/pull/187/commits/f42b38f9984b06c14389bbbdca7fea79c2f7880f#diff-90d5832691c95e10301ee697a568ddf7f8ad7609bc58143fe21352365953d6dbL51-L51)
  - [src/reducers/zoneSettings.js#L24-L24](https://github.com/cloudflare/cloudflare-plugin-frontend/pull/187/commits/f42b38f9984b06c14389bbbdca7fea79c2f7880f#diff-2b5e1962302fc54037475ef52602e29ff137b69da753cd929f6412793700907dL24-L24)
  - [src/reducers/zoneSettings.js#L25-L25](https://github.com/cloudflare/cloudflare-plugin-frontend/pull/187/commits/f42b38f9984b06c14389bbbdca7fea79c2f7880f#diff-2b5e1962302fc54037475ef52602e29ff137b69da753cd929f6412793700907dL25-L25)
  - [src/reducers/zones.js#L36-L36](https://github.com/cloudflare/cloudflare-plugin-frontend/pull/187/commits/f42b38f9984b06c14389bbbdca7fea79c2f7880f#diff-603b2e703e428d8190da2b0caedabd3ea6b3e40772d6c45e28c7f22028708852L36-L36)
  - [src/reducers/zones.js#L37-L37](https://github.com/cloudflare/cloudflare-plugin-frontend/pull/187/commits/f42b38f9984b06c14389bbbdca7fea79c2f7880f#diff-603b2e703e428d8190da2b0caedabd3ea6b3e40772d6c45e28c7f22028708852L37-L37)
</details>

If you would like to provide feedback to the JSFIX developers, then please leave a comment on this pull request.