### PR TITLE
Revert potential issue with Entitlements normalization

### DIFF
--- a/src/reducers/zoneEntitlements.js
+++ b/src/reducers/zoneEntitlements.js
@@ -1,4 +1,5 @@
 import * as ActionTypes from '../constants/ActionTypes';
+import { normalizeZoneEntitlements } from '../constants/Schemas';
 
 const initialState = {
   entities: {},
@@ -12,7 +13,12 @@ export function zoneEntitlementsReducer(state = initialState, action) {
         isFetching: true
       });
     case ActionTypes.ZONE_ENTITLEMENTS_SUCCESS:
+      let normalizedZoneEntitlements = normalizeZoneEntitlements(
+        action.zoneEntitlements
+      );
       let newEntities = Object.assign({}, state.entities);
+      newEntities[action.zoneId] =
+        normalizedZoneEntitlements.entities.entitlements;
       return Object.assign({}, state, {
         entities: newEntities,
         isFetching: false


### PR DESCRIPTION
Following our previous release of the APO plugin, we essentially bumped the `cloudflare-plugin-frontend` version from `v3.6.0` to `v3.8.0`, which includes the following changes: https://github.com/cloudflare/cloudflare-plugin-frontend/compare/v3.6.0...v3.8.0.

However, the APO plugin seem to only load its dashboard partially, at least on our testing Wordpress instance, due to the following error:

```
compiled.js?ver=4.12.5:18  action ZONE_FETCH_SETTINGS_SUCCESS @ 12:10:45.851
compiled.js?ver=4.12.5:21 Uncaught TypeError: Cannot read properties of undefined (reading 'zone.automatic_platform_optimization')
    at kl.render (compiled.js?ver=4.12.5:21:512376)
    at u._renderValidatedComponentWithoutOwnerOrContext (compiled.js?ver=4.12.5:18:163911)
    at u._renderValidatedComponent (compiled.js?ver=4.12.5:18:164018)
    at u.performInitialMount (compiled.js?ver=4.12.5:18:159921)
    at u.mountComponent (compiled.js?ver=4.12.5:18:158971)
    at Object.mountComponent (compiled.js?ver=4.12.5:5:40635)
    at u.performInitialMount (compiled.js?ver=4.12.5:18:160082)
    at u.mountComponent (compiled.js?ver=4.12.5:18:158971)
    at Object.mountComponent (compiled.js?ver=4.12.5:5:40635)
  at u.performInitialMount (compiled.js?ver=4.12.5:18:160082)
```

After reading the change we made removing the Railgun plugin, it seems that the following change of the `src/reducers/zoneEntitlements.js` file was indesirable, as it changes the logic related to the handling of the entitlements:

https://github.com/cloudflare/cloudflare-plugin-frontend/commit/fff5c4303e8490635e2533d452ab5e0cfcba020f#diff-1d811dd2703dec5a6ed09349810d7cfecd5b236c330d4802c2ab9cf6250c4603

While the error is about the `ZONE_UPDATE_SETTING_SUCCESS` action, and not about the entitlements, the code change seems to have removed some kind of merge operation, which is the most suspicious change which could cause that error.